### PR TITLE
adding locking and closed-checking to make sure that we do not write to ...

### DIFF
--- a/disconnect.go
+++ b/disconnect.go
@@ -38,6 +38,8 @@ package stompngo
 
 */
 func (c *Connection) Disconnect(h Headers) error {
+	c.subsLock.Lock()
+	defer c.subsLock.Unlock()
 	c.log(DISCONNECT, "start", h)
 	if !c.connected {
 		return ECONBAD

--- a/reader.go
+++ b/reader.go
@@ -55,7 +55,11 @@ func (c *Connection) reader() {
 			c.subs[sid] <- d
 			c.subsLock.Unlock()
 		} else {
-			c.input <- d
+			c.subsLock.Lock()
+			if c.connected {
+				c.input <- d
+			}
+			c.subsLock.Unlock()
 		}
 
 		c.log("RECEIVE", m.Command, m.Headers)


### PR DESCRIPTION
...closed channels

Thank you for all your work on this stompngo library, we've been putting it through its paces. In the course of doing that, we've discovered that sometimes when we Disconnect() a stompngo Connection object, we get a panic, as it has a goroutine trying to write to the c.input channel that's just been closed in the Disconnect() method.

I believe this patch should address that race condition.
